### PR TITLE
Update README/package.json, switch to -raw for gmail search.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Juttle Gmail Adapter
 
-Gmail adapter for juttle
+GMail adapter for the [Juttle data flow
+language](https://github.com/juttle/juttle).
 
 This uses the
 [nodejs API for google](https://www.npmjs.com/package/googleapis) to
@@ -9,17 +10,32 @@ read gmail messages. It also uses
 batched email fetches, something that the main google API does not
 currently support.
 
-# Installation / Setup
+## Examples
 
-Check out this repository and the juttle repository into a working directory.
+```juttle
+read gmail -from :5 days ago: -raw "to:me"
+   | reduce count() by from
+   | sort count -desc
+   | view table -title "Who sends me the most mail?";
+```
 
-Run `npm link` in each.
+```juttle
+read gmail -from :5 days ago: -to :1 day ago: -raw "to:me"
+   | batch -every :1h:
+   | reduce count()
+   | view timechart -title "When during the day do I get mail?"
+```
 
-Make sure the following is in your environment:
+## Installation / Setup
 
-`NODE_PATH=/usr/local/lib/node_modules`
+Like Juttle itself, the adapter is installed as a npm package. Both Juttle and
+the adapter need to be installed side-by-side:
 
-# Configuration
+```bash
+$ npm install juttle
+$ npm install juttle-gmail-adapter
+```
+## Configuration
 
 Configuration involves these steps:
 
@@ -27,7 +43,7 @@ Configuration involves these steps:
 2. Authorize a user using Oauth2 to use the application to access gmail.
 3. Add the appropriate configuration items to `.juttle/config.{js,json}`
 
-## Create application credentials
+### Create application credentials
 
 To create application credentials, follow the
 [nodejs quickstart instructions](https://developers.google.com/gmail/api/quickstart/nodejs). This
@@ -52,7 +68,7 @@ will result in a file on disk titled `client_secret.json` with this structure:
 
 You'll use this file in the next step.
 
-## Authorize a user using OAuth2
+### Authorize a user using OAuth2
 
 You need to create an oauth2 token that allows this program to read your email on your behalf.
 
@@ -63,7 +79,7 @@ This will provide a json config block to add to your `.juttle/config.{js,json}` 
 This will also use the gmail nodejs api to read the list of labels
 assocated with the authenticated user, to verify that the token was created successfully.
 
-## Add the appropriate configuration items to `.juttle/config.{js,json}`
+### Add the appropriate configuration items to `.juttle/config.{js,json}`
 
 `create_oauth_token.js` printed a configuration block like this:
 
@@ -117,11 +133,17 @@ Add the juttle-gmail-adapter section as a peer item below "adapters":
 }
 ```
 
-# Usage
+## Usage
 
-I've only used this for historical reads so far. -from and -to are
-honored. Currently the entire search expression is passed directly
-through to gmail as the
-[advanced search](https://support.google.com/mail/answer/7190?hl=en)
-expression.
+This adapter currently only supports historical reads.
+
+### Read Options
+
+Name | Type | Required | Description
+-----|------|----------|-------------
+`raw`  | string | no  | Use the following [advanced search](https://support.google.com/mail/answer/7190?hl=en) filter to select messages.
+`from` | moment | no | select messages after this time (inclusive)
+`to`   | moment | no | select messages before this time (exclusive)
+
+
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Juttle Gmail Adapter
 
-GMail adapter for the [Juttle data flow
+Gmail adapter for the [Juttle data flow
 language](https://github.com/juttle/juttle).
 
 This uses the
@@ -26,7 +26,7 @@ read gmail -from :5 days ago: -to :1 day ago: -raw "to:me"
    | view timechart -title "When during the day do I get mail?"
 ```
 
-## Installation / Setup
+## Installation
 
 Like Juttle itself, the adapter is installed as a npm package. Both Juttle and
 the adapter need to be installed side-by-side:
@@ -41,7 +41,7 @@ Configuration involves these steps:
 
 1. Create application credentials that allow your code to access the google nodejs APIs.
 2. Authorize a user using Oauth2 to use the application to access gmail.
-3. Add the appropriate configuration items to `.juttle/config.{js,json}`
+3. Add the appropriate configuration items to `.juttle/config.js`
 
 ### Create application credentials
 
@@ -74,12 +74,12 @@ You need to create an oauth2 token that allows this program to read your email o
 
 To do this, run `node create_oauth_token.js` from the juttle-gmail-adapter directory.
 
-This will provide a json config block to add to your `.juttle/config.{js,json}` file.
+This will provide a json config block to add to your `.juttle/config.js` file.
 
 This will also use the gmail nodejs api to read the list of labels
 assocated with the authenticated user, to verify that the token was created successfully.
 
-### Add the appropriate configuration items to `.juttle/config.{js,json}`
+### Add the appropriate configuration items to `.juttle/config.js`
 
 `create_oauth_token.js` printed a configuration block like this:
 
@@ -112,7 +112,7 @@ assocated with the authenticated user, to verify that the token was created succ
 }
 ```
 
-Add this configuration to your `.juttle/config.{js,json}` file. If you
+Add this configuration to your `.juttle/config.js` file. If you
 have an existing "adapters" section, for example:
 
 ```
@@ -145,5 +145,7 @@ Name | Type | Required | Description
 `from` | moment | no | select messages after this time (inclusive)
 `to`   | moment | no | select messages before this time (exclusive)
 
+## Contributing
 
-
+Want to contribute? Awesome! Don’t hesitate to file an issue or open a pull
+request.

--- a/lib/gmail-adapter.js
+++ b/lib/gmail-adapter.js
@@ -13,15 +13,20 @@ var Read = Juttle.proc.base.extend({
     procName: 'read-gmail',
 
     initialize: function(options, params, pname, location, program, juttle) {
-//        this.logger.info('intitialize', options, params);
+        this.logger.debug('intitialize', options, params);
         this.gmail = google.gmail('v1');
 
-        this.filter = '';
-        if (params.filter_ast && params.filter_ast.type === 'SimpleFilterTerm') {
-            this.filter = params.filter_ast.expression.value;
+        var allowed_options = ['raw', 'from', 'to'];
+        var unknown = _.difference(_.keys(options), allowed_options);
+
+        if (unknown.length > 0) {
+            throw new Error('Unknown option ' + unknown[0]);
         }
 
-        this.logger.info("Filter Expression:", params.filter_ast.expression.value);
+        this.raw = options.raw;
+
+        this.logger.info("Filter Expression:", this.raw);
+
         Promise.promisifyAll(this.gmail.users.messages);
         this.options = options;
     },
@@ -30,7 +35,7 @@ var Read = Juttle.proc.base.extend({
         var self = this;
 
         // Build a search expression given the options.
-        var search = self.filter;
+        var search = self.raw;
 
         // The gmail search expression only has per-day granularity,
         // so we quantize the -from and -to to the nearest day and do

--- a/package.json
+++ b/package.json
@@ -1,13 +1,16 @@
 {
   "name": "juttle-gmail-adapter",
-  "version": "0.1.0",
-  "description": "",
+  "version": "0.1.1",
+  "description": "Juttle adapter for GMail",
+  "keywords": ["juttle", "adapter", "gmail"],
+  "homepage": "https://github.com/juttle/juttle-gmail-adapter",
+  "bugs": "https://github.com/juttle/juttle-gmail-adapter/issues",
+  "license": "Apache-2.0",
   "main": "index.js",
+  "repository": "juttle/juttle-gmail-adapter",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "author": "",
-  "license": "Apache-2.0",
   "dependencies": {
       "batchelor": "^2.0.1",
       "bluebird": "^3.0.5",
@@ -15,6 +18,10 @@
       "google-auth-library": "^0.9.7",
       "moment": "^2.10.6",
       "underscore": "^1.8.3"
+  },
+  "engines": {
+    "node": ">=4.2.0",
+    "npm": ">=2.14.7"
   }
 }
 


### PR DESCRIPTION
Update README.md/package.json to follow the structure used by the
other adapters.

Also modify the adapter to use -raw for the gmail search expression
instead of the filter term.

@vladvega @demmer @dmajda 