### PR TITLE
Get live programs working.

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,8 +135,6 @@ Add the juttle-gmail-adapter section as a peer item below "adapters":
 
 ## Usage
 
-This adapter currently only supports historical reads.
-
 ### Read Options
 
 Name | Type | Required | Description

--- a/docs/adapter_impl_notes.md
+++ b/docs/adapter_impl_notes.md
@@ -12,9 +12,11 @@ More sophisticated adapters work together with the juttle optimizer to push aggr
 
 ## Live vs Historical
 
-Juttle's ``read`` command specifies a timerange based on the values of the ``-from`` and ``-to`` options. When the ``-to`` option is less than the current time, an adapter need only fetch the matching set of messages for the provided timerange. Such a program is called *historical*. When the ``-to`` option is greater than the current time, the adapter must also watch for new messages and pass them to the program. Such a problem is called *live*. A program can be both live and historical, with a ``-from`` in the past and a ``-to`` in the future. In that case, the adapter must fetch both old and newly-arriving messages.
+Juttle's ``read`` command specifies a timerange based on the values of the ``-from``, ``-to``, and ``-last`` options. When the timerange specified by ``-from/-to/-last`` is in the past, an adapter need only fetch the matching set of messages for the provided timerange. Such a program is called *historical*. When a part of the timerange is in the future, the adapter must also watch for new messages and pass them to the program. Such a problem is called *live*. A program can be both live and historical, with a ``-from`` in the past and a ``-to`` in the future. In that case, the adapter must fetch both old and newly-arriving messages.
 
-Although Gmail messages have a natural time values (the time the message was received), not all backends do. If your backend does not have meaningful time values, but was given a timerange in the ``read`` proc, your adapter should return an error.
+Although Gmail messages have natural time values (the time the message was received), not all backends do. If your backend does not have meaningful time values, but was given a timerange in the ``read`` proc, your adapter should return an error.
+
+For more information on Time Range Semantics, see [this page](https://github.com/juttle/juttle/wiki/Time-Range-Semantics).
 
 ## Fields and Searching
 

--- a/lib/gmail-adapter.js
+++ b/lib/gmail-adapter.js
@@ -1,4 +1,5 @@
 var Juttle = require('juttle/lib/runtime').Juttle;
+var JuttleErrors = require('juttle/lib/errors');
 var JuttleMoment = require('juttle/lib/moment/juttle-moment');
 var Promise = require('bluebird');
 var google = require('googleapis');
@@ -16,11 +17,43 @@ var Read = Juttle.proc.base.extend({
         this.logger.debug('intitialize', options, params);
         this.gmail = google.gmail('v1');
 
-        var allowed_options = ['raw', 'from', 'to'];
+        var time_related_options = ['from', 'to', 'last'];
+        var allowed_options = time_related_options.concat(['raw']);
         var unknown = _.difference(_.keys(options), allowed_options);
 
         if (unknown.length > 0) {
-            throw new Error('Unknown option ' + unknown[0]);
+            throw JuttleErrors.syntaxError('RT-UNKNOWN-OPTION-ERROR',
+                                           {proc: 'gmail', option: unknown[0], location: location});
+        }
+
+        // One of 'from', 'to', or 'last' must be present.
+        var opts = _.intersection(_.keys(options), time_related_options);
+        if (opts.length === 0) {
+            // Waiting on a juttle release that incorporates https://github.com/juttle/juttle/pull/108
+            //throw JuttleErrors.syntaxError('RT-MISSING-TIMERANGE-ERROR', {location: location});
+            throw new Error('Error: One of -from, -to, or -last must be specified to define a query time range');
+        }
+
+        // If 'from'/'to' are present, 'last' can not be present.
+        if ((_.has(options, 'from') || _.has(options, 'to')) &&
+            _.has(options, 'last')) {
+            throw JuttleErrors.syntaxError('RT-LAST-FROM-TO-ERROR', {location: location});
+        }
+
+        // 'from' must be before 'to'
+        if (_.has(options, 'from') && _.has(options, 'to') &&
+            options.from > options.to) {
+            throw JuttleErrors.syntaxError('RT-TO-FROM-MOMENT-ERROR', {location: location});
+        }
+
+        // If 'last' is specified, set appropriate 'from'/'to'
+        if (_.has(options, 'last')) {
+            this.from = JuttleMoment.now().subtract(options.last);
+            this.to = JuttleMoment.now();
+        } else {
+            // Initialize from/to if necessary.
+            this.from = options.from || JuttleMoment.now();
+            this.to = options.to || JuttleMoment.now();
         }
 
         this.raw = options.raw;
@@ -28,15 +61,12 @@ var Read = Juttle.proc.base.extend({
         this.delay = options.delay || JuttleMoment.duration(1, 's');
 
         Promise.promisifyAll(this.gmail.users.messages);
-        this.options = options;
     },
 
     start: function() {
         var self = this;
 
-        self.options.from = self.options.from || new JuttleMoment(0);
-
-        return self.get_messages_for_timerange(self.options.from, self.options.to);
+        return self.get_messages_for_timerange(self.from, self.to);
     },
 
     teardown: function() {
@@ -57,15 +87,12 @@ var Read = Juttle.proc.base.extend({
         // additional filtering in get_messages().
 
         // XXX/mstemm not sure how the time zone is set. It's definitely not in UTC.
+        search += " after:" + JuttleMoment.format(from, "YYYY/MM/DD", "US/Pacific");
 
-        if (from) {
-            search += " after:" + JuttleMoment.format(from, "YYYY/MM/DD", "US/Pacific");
-        }
-
-        if (to) {
-            // Add 1 day to to and then quantize to a day. This
-            // results in the next day, such that the before: date is
-            // always in the future.
+        // Add 1 day to to and then quantize to a day. This
+        // results in the next day, such that the before: date is
+        // always in the future.
+        if (! self.to.isEnd()) {
             search += " before:" + JuttleMoment.format(to.add(JuttleMoment.duration(1, "d")), "YYYY/MM/DD", "US/Pacific");
         }
 
@@ -90,8 +117,7 @@ var Read = Juttle.proc.base.extend({
             // If to is in the future, arrange with the scheduler to
             // get all messages from the timestamp of the last message
             // to "to". Otherwise we're done.
-            if (to === undefined ||
-                to.gt(now)) {
+            if (to.gt(now)) {
                 var next_poll = now.add(self.delay);
                 var next_from = from;
 
@@ -170,13 +196,11 @@ var Read = Juttle.proc.base.extend({
                 var message = part.body;
                 var time = new JuttleMoment({rawDate: new Date(Number(message.internalDate))});
 
-                if (from &&
-                    time.lt(from)) {
+                if (time.lt(from)) {
                     return;
                 }
 
-                if (to &&
-                    time.gt(to)) {
+                if (time.gt(to)) {
                     return;
                 }
 

--- a/lib/gmail-adapter.js
+++ b/lib/gmail-adapter.js
@@ -25,7 +25,7 @@ var Read = Juttle.proc.base.extend({
 
         this.raw = options.raw;
 
-        this.logger.info("Filter Expression:", this.raw);
+        this.delay = options.delay || JuttleMoment.duration(1, 's');
 
         Promise.promisifyAll(this.gmail.users.messages);
         this.options = options;
@@ -34,8 +34,23 @@ var Read = Juttle.proc.base.extend({
     start: function() {
         var self = this;
 
+        self.options.from = self.options.from || new JuttleMoment(0);
+
+        return self.get_messages_for_timerange(self.options.from, self.options.to);
+    },
+
+    teardown: function() {
+    },
+
+    // Non juttle proc methods below here
+    get_messages_for_timerange: function(from, to) {
+        this.logger.debug('get_messages_for_timerange from=' + from + " to=" + to);
+        var self = this;
+
         // Build a search expression given the options.
-        var search = self.raw;
+        var search = self.raw || "";
+
+        var now = new JuttleMoment();
 
         // The gmail search expression only has per-day granularity,
         // so we quantize the -from and -to to the nearest day and do
@@ -43,15 +58,19 @@ var Read = Juttle.proc.base.extend({
 
         // XXX/mstemm not sure how the time zone is set. It's definitely not in UTC.
 
-        if (self.options.from) {
-            search += " after:" + JuttleMoment.format(self.options.from, "YYYY/MM/DD", "US/Pacific");
+        if (from) {
+            search += " after:" + JuttleMoment.format(from, "YYYY/MM/DD", "US/Pacific");
         }
 
-        if (self.options.to) {
-            search += " before:" + JuttleMoment.format(self.options.to, "YYYY/MM/DD", "US/Pacific");
+        if (to) {
+            // Add 1 day to to and then quantize to a day. This
+            // results in the next day, such that the before: date is
+            // always in the future.
+            search += " before:" + JuttleMoment.format(to.add(JuttleMoment.duration(1, "d")), "YYYY/MM/DD", "US/Pacific");
         }
 
-        self.get_messages(search)
+        this.logger.debug("Search string:", search);
+        return self.get_messages(from, to, search)
         .call("sort", function(a, b) {
             if (a.time.lt(b.time)) {
                 return -1;
@@ -65,19 +84,41 @@ var Read = Juttle.proc.base.extend({
             if (messages && messages.length > 0) {
                 self.emit(messages);
             }
-            self.eof();
-        }).catch(function(err) {
+            return messages;
+        })
+        .then(function(messages) {
+            // If to is in the future, arrange with the scheduler to
+            // get all messages from the timestamp of the last message
+            // to "to". Otherwise we're done.
+            if (to === undefined ||
+                to.gt(now)) {
+                var next_poll = now.add(self.delay);
+                var next_from = from;
+
+                if (messages && messages.length > 0) {
+                    var last_time = _.last(messages).time;
+                    next_from = last_time.add(JuttleMoment.duration(1, 'ms'));
+                }
+
+                self.program.scheduler.schedule(next_poll.unixms(), function() {
+                    self.get_messages_for_timerange(next_from, to);
+                });
+            } else {
+                self.eof();
+            }
+        })
+        .catch(function(err) {
             self.logger.error("Could not read latest emails:", err);
         });
     },
 
-    get_messages: function(search, pageToken) {
+    get_messages: function(from, to, search, pageToken) {
         var self = this;
 
         var opts = {
             auth: auth,
             userId: 'me',
-            q: search,
+            q: search
         };
 
         if (pageToken) {
@@ -91,7 +132,7 @@ var Read = Juttle.proc.base.extend({
                 return [];
             }
 
-            self.logger.info("Got " + response.messages.length + " potential messages");
+            self.logger.debug("Got " + response.messages.length + " potential messages");
 
             pageToken = response.nextPageToken;
 
@@ -129,13 +170,13 @@ var Read = Juttle.proc.base.extend({
                 var message = part.body;
                 var time = new JuttleMoment({rawDate: new Date(Number(message.internalDate))});
 
-                if (self.options.from &&
-                    time.lt(self.options.from)) {
+                if (from &&
+                    time.lt(from)) {
                     return;
                 }
 
-                if (self.options.to &&
-                    time.gt(self.options.to)) {
+                if (to &&
+                    time.gt(to)) {
                     return;
                 }
 
@@ -151,7 +192,7 @@ var Read = Juttle.proc.base.extend({
             });
 
             if (pageToken) {
-                return self.get_messages(search, pageToken).then(function(remaining_messages) {
+                return self.get_messages(from, to, search, pageToken).then(function(remaining_messages) {
                     return messages.concat(remaining_messages);
                 });
             } else {
@@ -160,11 +201,6 @@ var Read = Juttle.proc.base.extend({
         });
     },
 
-    teardown: function() {
-    },
-
-
-    // Non juttle proc methods below here
     find_header: function(message, name) {
         var self = this;
 

--- a/lib/gmail-adapter.js
+++ b/lib/gmail-adapter.js
@@ -48,12 +48,12 @@ var Read = Juttle.proc.base.extend({
 
         // If 'last' is specified, set appropriate 'from'/'to'
         if (_.has(options, 'last')) {
-            this.from = JuttleMoment.now().subtract(options.last);
-            this.to = JuttleMoment.now();
+            this.from = program.now.subtract(options.last);
+            this.to = program.now;
         } else {
             // Initialize from/to if necessary.
-            this.from = options.from || JuttleMoment.now();
-            this.to = options.to || JuttleMoment.now();
+            this.from = options.from || program.now;
+            this.to = options.to || program.now;
         }
 
         this.raw = options.raw;


### PR DESCRIPTION
The adapter now honors a -to that may be in the future. When -to is in
the future, it polls until the current time is greater than -to.

This required adding an intermediate function
get_messages_for_timerange that handled the details of creating the
gmail search expression, sorting the results, etc, as well as using
the scheduler to schedule a future call to get_messages_for_timerange().

Also fix a bug with -to handling--when rounded to a date for the gmail
search string, it should always be for a date after the current date.

@VladVega @davidvgalbraith do you know if there's a better way to handle line 100? (adding 1 millisecond to the end time). I saw mention of an epsilon within JuttleMoment but wasn't quite sure how to use it.

This fixes #7.