### PR TITLE
Add basic travis-driven lint/testing.

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,14 @@
+{
+    "maxErrors": -1,
+    "requireCurlyBraces": [
+        "if",
+        "else",
+        "for",
+        "while",
+        "do",
+        "try",
+        "catch"
+    ],
+    "disallowTrailingWhitespace": true,
+    "validateIndentation": 4
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+language: node_js
+
+cache:
+  directories:
+    - node_modules
+
+addons:
+  apt:
+    sources:
+        - ubuntu-toolchain-r-test
+    packages:
+        - g++-4.8
+
+before_install:
+    - export CXX="g++-4.8"
+
+node_js:
+    - '4.2'
+    - '5.0'
+
+before_script:
+    - npm install juttle@0.1.x
+    - npm install -g jshint
+    - npm install -g jscs
+
+script:
+    - npm run -s lint
+    - npm test

--- a/create_oauth_token.js
+++ b/create_oauth_token.js
@@ -118,7 +118,7 @@ function listLabels(auth) {
             return;
         }
         var labels = response.labels;
-        if (labels.length == 0) {
+        if (labels.length === 0) {
             console.log('No labels found.');
         } else {
             console.log('Labels:');

--- a/package.json
+++ b/package.json
@@ -9,7 +9,10 @@
   "main": "index.js",
   "repository": "juttle/juttle-gmail-adapter",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+      "test": "mocha",
+      "jshint": "jshint *.js lib/*.js test/*.js",
+      "style": "jscs *.js lib/*.js test/*.js",
+      "lint": "npm run jshint & npm run style"
   },
   "dependencies": {
       "batchelor": "^2.0.1",
@@ -21,6 +24,10 @@
   },
   "peerDependencies": {
       "juttle": "0.1.x"
+  },
+  "devDependencies": {
+      "chai": "^3.4.1",
+      "mocha": "^2.3.4"
   },
   "engines": {
     "node": ">=4.2.0",

--- a/test/gmail-adapter.spec.js
+++ b/test/gmail-adapter.spec.js
@@ -1,0 +1,37 @@
+var _ = require('underscore');
+var juttle_test_utils = require('juttle/test/runtime/specs/juttle-test-utils');
+var Juttle = require('juttle/lib/runtime').Juttle;
+var GmailAdapter = require('../');
+var check_juttle = juttle_test_utils.check_juttle;
+
+describe('gmail adapter', function() {
+
+    before(function() {
+
+        // The config is provided via the environment to avoid putting
+        // sensitive information like ids/auth tokens in source
+        // files. If you want to run this test using your own setup,
+        // json stringify the portion of your config under the
+        // "juttle-gmail-adapter" object and set it in the environment
+        // as JUTTLE_GMAIL_CONFIG.
+
+        if (! _.has(process.env, "JUTTLE_GMAIL_CONFIG")) {
+            throw new Error("To run this test, you must provide the adapter config via the environment as JUTTLE_GMAIL_CONFIG.");
+        }
+
+        var config_text = process.env.JUTTLE_GMAIL_CONFIG;
+        var config = JSON.parse(config_text);
+        var adapter = GmailAdapter(config, Juttle);
+
+        Juttle.adapters.register(adapter.name, adapter);
+    });
+
+    it('basic email reading', function() {
+        this.timeout(60000);
+        return check_juttle({
+            program: 'read gmail -from :6 months ago: | reduce count() by from | sort count -desc | view table -title "Who sends me the most mail?"'
+        });
+    });
+});
+
+

--- a/test/gmail-adapter.spec.js
+++ b/test/gmail-adapter.spec.js
@@ -3,6 +3,7 @@ var juttle_test_utils = require('juttle/test/runtime/specs/juttle-test-utils');
 var Juttle = require('juttle/lib/runtime').Juttle;
 var GmailAdapter = require('../');
 var check_juttle = juttle_test_utils.check_juttle;
+var expect = require('chai').expect;
 
 describe('gmail adapter', function() {
 
@@ -30,6 +31,10 @@ describe('gmail adapter', function() {
         this.timeout(60000);
         return check_juttle({
             program: 'read gmail -from :6 months ago: | reduce count() by from | sort count -desc | view table -title "Who sends me the most mail?"'
+        })
+        .then(function(result) {
+            expect(result.errors).to.have.length(0);
+            expect(result.warnings).to.have.length(0);
         });
     });
 });


### PR DESCRIPTION
Add a .travis.yml that runs lint via npm -s lint and tests via npm
test. Fix one lint error that the lint check found.

Add a basic unit test that reads a bunch of emails. To avoid putting
api keys/auth tokens in any source code, the actual adapter config is
provided via the environment. Travis is configured to read emails for
a test user and sets the environment variable with the appropriate
config.

This fixes #12.

@davidvgalbraith @demmer @go-oleg 