### PR TITLE
Drop sourceType property from read

### DIFF
--- a/lib/gmail-adapter.js
+++ b/lib/gmail-adapter.js
@@ -9,7 +9,6 @@ var Batchelor = require('batchelor');
 var auth;
 
 var Read = Juttle.proc.base.extend({
-    sourceType: 'batch',
     procName: 'read-gmail',
 
     initialize: function(options, params, pname, location, program, juttle) {


### PR DESCRIPTION
As read now inherits from Juttle source proc and program checks for
that, the sourceType property is not needed.

refs: https://github.com/juttle/juttle/pull/110