### PR TITLE
Add support for filter expressions.

### DIFF
--- a/docs/adapter_impl_notes.md
+++ b/docs/adapter_impl_notes.md
@@ -53,7 +53,7 @@ The following comparison operators are supported:
 * ~, =~ (wildcard operator). This is because Gmail's header searches match on substrings and do not perform exact matches.
 * !~ (wildcard negation).
 
-These header matches are pushed into the Gmail API search expression. Logical operators such as ``AND``, ``OR``, and ``NOT`` join terms in the expression.
+These header matches are pushed into the Gmail API search expression. Logical operators such as ``AND``, ``OR``, and ``NOT`` join terms in the expression, and parentheses can be used for logical grouping and nesting.
 
 Full-text search is supported by the Gmail API, so any full-text searches are passed through to the search expression.
 
@@ -133,7 +133,7 @@ Code is one of the values in [juttle-error-strings-en-US.json](https://github.co
 
 ## The ``filter_ast`` expression
 
-The filter expression is parsed by the juttle compiler and provided to the adapter as params.filter_ast, which is the output of the juttle compiler. The best way to parse a filter expression is by using the [ASTVisitor class](https://github.com/juttle/juttle/blob/master/lib/compiler/ast-visitor.js) to step through the ast with callbacks for the terms of the filter expression.
+The filter expression is parsed by the juttle compiler and provided to the adapter as params.filter_ast, which is the output of the juttle compiler. The best way to parse a filter expression is by using the [ASTVisitor class](https://github.com/juttle/juttle/blob/master/lib/compiler/ast-visitor.js) to step through the ast with callbacks for the terms of the filter expression to build up a backend-specific search expression. The gmail adapter does this in [filter-gmail-compiler.js](../lib/filter-gmail-compiler.js).
 
 ## Constructing Points
 

--- a/lib/filter-gmail-compiler.js
+++ b/lib/filter-gmail-compiler.js
@@ -1,0 +1,131 @@
+// Compiler that transforms filter expression AST into a gmail search expression.
+//
+// The expression is returned from the compile method.
+
+var ASTVisitor = require('juttle/lib/compiler/ast-visitor');
+var JuttleErrors = require('juttle/lib/errors');
+var JuttleMoment = require('juttle/lib/moment').JuttleMoment;
+var _ = require('underscore');
+
+// FilterGmailCompiler derives from ASTVisitor which provides a way to
+// traverse the abstract syntax tree that the juttle compiler
+// generates for the read command's filter expression.
+//
+// While traversing the tree, callbacks are called for the various
+// parts of the filter expression. The FilterGmailCompiler object maps
+// individual items in the tree into appropriate gmail advanced search
+// (https://support.google.com/mail/answer/7190?hl=en) terms. As the
+// tree is traversed, these items are combined into a complete gmail
+// search expression. This is used when reading messages.
+
+var FilterGmailCompiler = ASTVisitor.extend({
+    initialize: function(options) {
+        this.location = options.location;
+        this.source = options.source;
+        this.supported_headers = ["from", "to", "subject", "cc", "bcc"];
+    },
+
+    compile: function(node) {
+        return this.visit(node);
+    },
+
+    visitStringLiteral: function(node) {
+        return node.value;
+    },
+
+    visitFilterLiteral: function(node) {
+        return this.visit(node.ast);
+    },
+
+    visitUnaryExpression: function(node) {
+        switch (node.operator) {
+            case 'NOT':
+                return '-' + this.visit(node.expression);
+
+            // '*' is the field dereferencing operator. For example,
+            // given a search string from ~ 'bob', the UnaryExpression
+            // * on from means "the field called from".
+            case '*':
+                return this.visit(node.expression);
+
+            default:
+                throw this.source.compile_error('RT-ADAPTER-UNSUPPORTED-FILTER',
+                                                {proc: 'read gmail', filter: "operator " + node.operator});
+        }
+    },
+
+    visitBinaryExpression: function(node) {
+        var left, right, filter;
+
+        switch (node.operator) {
+            case 'AND':
+                left = this.visit(node.left);
+                right = this.visit(node.right);
+
+                filter = "(" + left + " " + right + ")";
+                break;
+
+            case 'OR':
+                left = this.visit(node.left);
+                right = this.visit(node.right);
+
+                filter = "(" + left + " OR " + right + ")";
+
+                break;
+
+            // The gmail search syntax only supports substring matches
+            // (as compared to exact matches), so we only support
+            // substring matches here.
+            case '=~':
+            case '~':
+                var header = this.visit(node.left);
+                var value = this.visit(node.right);
+
+                if (! _.contains(this.supported_headers, header)) {
+                    throw this.source.compile_error('RT-ADAPTER-UNSUPPORTED-FILTER',
+                                                    {proc: 'read gmail', filter: "searching on header " + header});
+                }
+
+                filter = header + ":" + "\"" + value + "\"";
+
+                break;
+
+            case '!~':
+                var header = this.visit(node.left);
+                var value = this.visit(node.right);
+
+                if (! _.contains(this.supported_headers, header)) {
+                    throw this.source.compile_error('RT-ADAPTER-UNSUPPORTED-FILTER',
+                                                    {proc: 'read gmail', filter: "searching on header " + header});
+                }
+
+                filter = "-" + header + ":" + "\"" + value + "\"";
+
+                break;
+
+            default:
+                throw this.source.compile_error('RT-ADAPTER-UNSUPPORTED-FILTER',
+                                                {proc: 'read gmail', filter: "operator " + node.operator});
+        }
+
+        return filter;
+    },
+
+    visitExpressionFilterTerm: function(node) {
+        return this.visit(node.expression);
+    },
+
+    visitSimpleFilterTerm: function(node) {
+        switch (node.expression.type) {
+            case 'StringLiteral':
+            case 'FilterLiteral':
+                return "\"" + this.visit(node.expression) + "\"";
+
+            default:
+                throw this.source.compile_error('RT-ADAPTER-UNSUPPORTED-FILTER',
+                                                {proc: 'read gmail', filter: "filter term " + node.expression.type});
+        }
+    }
+});
+
+module.exports = FilterGmailCompiler;

--- a/lib/filter-gmail-compiler.js
+++ b/lib/filter-gmail-compiler.js
@@ -21,7 +21,6 @@ var _ = require('underscore');
 var FilterGmailCompiler = ASTVisitor.extend({
     initialize: function(options) {
         this.location = options.location;
-        this.source = options.source;
         this.supported_headers = ["from", "to", "subject", "cc", "bcc"];
     },
 
@@ -49,7 +48,8 @@ var FilterGmailCompiler = ASTVisitor.extend({
                 return this.visit(node.expression);
 
             default:
-                throw this.source.compile_error('RT-ADAPTER-UNSUPPORTED-FILTER',
+
+                throw JuttleErrors.compileError('RT-ADAPTER-UNSUPPORTED-FILTER',
                                                 {proc: 'read gmail', filter: "operator " + node.operator});
         }
     },
@@ -77,12 +77,11 @@ var FilterGmailCompiler = ASTVisitor.extend({
             // (as compared to exact matches), so we only support
             // substring matches here.
             case '=~':
-            case '~':
                 var header = this.visit(node.left);
                 var value = this.visit(node.right);
 
                 if (! _.contains(this.supported_headers, header)) {
-                    throw this.source.compile_error('RT-ADAPTER-UNSUPPORTED-FILTER',
+                    throw JuttleErrors.compileError('RT-ADAPTER-UNSUPPORTED-FILTER',
                                                     {proc: 'read gmail', filter: "searching on header " + header});
                 }
 
@@ -95,7 +94,7 @@ var FilterGmailCompiler = ASTVisitor.extend({
                 var value = this.visit(node.right);
 
                 if (! _.contains(this.supported_headers, header)) {
-                    throw this.source.compile_error('RT-ADAPTER-UNSUPPORTED-FILTER',
+                    throw JuttleErrors.compileError('RT-ADAPTER-UNSUPPORTED-FILTER',
                                                     {proc: 'read gmail', filter: "searching on header " + header});
                 }
 
@@ -104,7 +103,7 @@ var FilterGmailCompiler = ASTVisitor.extend({
                 break;
 
             default:
-                throw this.source.compile_error('RT-ADAPTER-UNSUPPORTED-FILTER',
+                throw JuttleErrors.compileError('RT-ADAPTER-UNSUPPORTED-FILTER',
                                                 {proc: 'read gmail', filter: "operator " + node.operator});
         }
 
@@ -122,7 +121,7 @@ var FilterGmailCompiler = ASTVisitor.extend({
                 return "\"" + this.visit(node.expression) + "\"";
 
             default:
-                throw this.source.compile_error('RT-ADAPTER-UNSUPPORTED-FILTER',
+                throw JuttleErrors.compileError('RT-ADAPTER-UNSUPPORTED-FILTER',
                                                 {proc: 'read gmail', filter: "filter term " + node.expression.type});
         }
     }

--- a/lib/gmail-adapter.js
+++ b/lib/gmail-adapter.js
@@ -58,11 +58,11 @@ var Read = Juttle.proc.base.extend({
         }
 
         this.raw = options.raw;
-        this.filter_search_expr = '';
+        this.filter_search_expr = undefined;
 
         if (params.filter_ast) {
             this.logger.debug("Filter ast: ", params.filter_ast);
-            var compiler = new FilterGmailCompiler({source: this, location: location});
+            var compiler = new FilterGmailCompiler({location: location});
             this.filter_search_expr = compiler.compile(params.filter_ast);
             this.logger.debug("Filter expression: ", this.filter_search_expr);
         }
@@ -89,7 +89,7 @@ var Read = Juttle.proc.base.extend({
         // Build a search expression given the options.
         var search = self.raw || "";
 
-        if (this.filter_search_expr !== '') {
+        if (this.filter_search_expr !== undefined) {
             search += " " + this.filter_search_expr;
         }
 

--- a/lib/gmail-adapter.js
+++ b/lib/gmail-adapter.js
@@ -6,6 +6,7 @@ var google = require('googleapis');
 var googleAuth = require('google-auth-library');
 var _ = require('underscore');
 var Batchelor = require('batchelor');
+var FilterGmailCompiler = require('./filter-gmail-compiler');
 
 var auth;
 
@@ -22,28 +23,28 @@ var Read = Juttle.proc.base.extend({
         var unknown = _.difference(_.keys(options), allowed_options);
 
         if (unknown.length > 0) {
-            throw JuttleErrors.syntaxError('RT-UNKNOWN-OPTION-ERROR',
-                                           {proc: 'gmail', option: unknown[0], location: location});
+            throw this.compile_error('RT-UNKNOWN-OPTION-ERROR',
+                                     {proc: 'read gmail', option: unknown[0]});
         }
 
         // One of 'from', 'to', or 'last' must be present.
         var opts = _.intersection(_.keys(options), time_related_options);
         if (opts.length === 0) {
             // Waiting on a juttle release that incorporates https://github.com/juttle/juttle/pull/108
-            //throw JuttleErrors.syntaxError('RT-MISSING-TIMERANGE-ERROR', {location: location});
+            //throw this.compile_error('RT-MISSING-TIME-RANGE-ERROR');
             throw new Error('Error: One of -from, -to, or -last must be specified to define a query time range');
         }
 
         // If 'from'/'to' are present, 'last' can not be present.
         if ((_.has(options, 'from') || _.has(options, 'to')) &&
             _.has(options, 'last')) {
-            throw JuttleErrors.syntaxError('RT-LAST-FROM-TO-ERROR', {location: location});
+            throw this.compile_error('RT-LAST-FROM-TO-ERROR');
         }
 
         // 'from' must be before 'to'
         if (_.has(options, 'from') && _.has(options, 'to') &&
             options.from > options.to) {
-            throw JuttleErrors.syntaxError('RT-TO-FROM-MOMENT-ERROR', {location: location});
+            throw this.compile_error('RT-TO-FROM-MOMENT-ERROR');
         }
 
         // If 'last' is specified, set appropriate 'from'/'to'
@@ -57,6 +58,14 @@ var Read = Juttle.proc.base.extend({
         }
 
         this.raw = options.raw;
+        this.filter_search_expr = '';
+
+        if (params.filter_ast) {
+            this.logger.debug("Filter ast: ", params.filter_ast);
+            var compiler = new FilterGmailCompiler({source: this, location: location});
+            this.filter_search_expr = compiler.compile(params.filter_ast);
+            this.logger.debug("Filter expression: ", this.filter_search_expr);
+        }
 
         this.delay = options.delay || JuttleMoment.duration(1, 's');
 
@@ -79,6 +88,10 @@ var Read = Juttle.proc.base.extend({
 
         // Build a search expression given the options.
         var search = self.raw || "";
+
+        if (this.filter_search_expr !== '') {
+            search += " " + this.filter_search_expr;
+        }
 
         var now = new JuttleMoment();
 

--- a/test/filter-gmail-compiler.spec.js
+++ b/test/filter-gmail-compiler.spec.js
@@ -1,0 +1,194 @@
+var JuttleParser = require('juttle/lib/parser');
+var SemanticPass = require('juttle/lib/compiler/semantic');
+var JuttleErrors = require('juttle/lib/errors');
+var JuttleMoment = require('juttle/lib/moment').JuttleMoment;
+var FilterGmailCompiler = require('../lib/filter-gmail-compiler');
+var expect = require('chai').expect;
+
+function verify_compile_error(source, filter) {
+    var ast = JuttleParser.parseFilter(source).ast;
+
+    var semantic = new SemanticPass({ now: new JuttleMoment() });
+    semantic.sa_expr(ast);
+
+    var compiler = new FilterGmailCompiler({location: ast.location});
+    try {
+        var search_expr = compiler.compile(ast);
+    } catch (e) {
+        expect(e).to.be.instanceOf(JuttleErrors.CompileError);
+        expect(e.code).to.equal("RT-ADAPTER-UNSUPPORTED-FILTER");
+        expect(e.info.filter).to.equal(filter);
+    }
+}
+
+function verify_compile_success(source, expected) {
+    var ast = JuttleParser.parseFilter(source).ast;
+
+    var semantic = new SemanticPass({ now: new JuttleMoment() });
+    semantic.sa_expr(ast);
+
+    var compiler = new FilterGmailCompiler({location: ast.location});
+    var search_expr = compiler.compile(ast);
+    expect(search_expr).to.equal(expected);
+}
+
+describe('gmail filter', function() {
+
+    describe(' properly returns errors for invalid filtering expressions like ', function() {
+
+        var invalid_unary_operators = ['!', '-'];
+
+        invalid_unary_operators.forEach(function(op) {
+            it('using unary operator ' + op + ' in field specifications', function() {
+                verify_compile_error("subject ~ " + op + " \"foo\"",
+                                     "operator " + op);
+            });
+        });
+
+        var invalid_operators = ['==', '!=', '<', '<=', '>', '>=', 'in'];
+        invalid_operators.forEach(function(op) {
+            it('using ' + op + ' in field comparisons', function() {
+                verify_compile_error("subject " + op + " \"foo\"",
+                                     "operator " + op);
+            });
+        });
+
+        it('matching on unsupported headers', function() {
+            verify_compile_error("not_a_header ~ \"foo\"",
+                                 "searching on header not_a_header");
+        });
+
+        it('not a filter expression or string', function() {
+            verify_compile_error("+ 1",
+                                 "filter term UnaryExpression");
+        });
+    });
+
+    describe(' properly returns gmail search expressions for valid cases like ', function() {
+        it('Simple full-text match', function() {
+            verify_compile_success("\"foo\"",
+                                   "\"foo\"");
+        });
+
+        it('Simple full-text match using a phrase', function() {
+            verify_compile_success("\"a phrase\"",
+                                   "\"a phrase\"");
+        });
+
+        var supported_headers = new FilterGmailCompiler({location: 0}).supported_headers;
+        supported_headers.forEach(function(hdr) {
+            it('Matching with header ' + hdr, function() {
+                verify_compile_success(hdr + " ~ \"foo\"",
+                                       hdr + ":\"foo\"");
+            });
+        });
+
+        supported_headers.forEach(function(hdr) {
+            it('Matching with header ' + hdr + ' and a phrase', function() {
+                verify_compile_success(hdr + " ~ \"a phrase\"",
+                                       hdr + ":\"a phrase\"");
+            });
+        });
+
+        it('Not matching a single header', function() {
+            verify_compile_success("subject !~ \"foo\"",
+                                   "-subject:\"foo\"");
+        });
+
+        it('Not matching a single header with a phrase', function() {
+            verify_compile_success("subject !~ \"a phrase\"",
+                                   "-subject:\"a phrase\"");
+        });
+
+        it('Matching a single header AND a full-text search', function() {
+            verify_compile_success("\"some text\" AND subject ~ \"a phrase\"",
+                                   "(\"some text\" subject:\"a phrase\")");
+        });
+
+        it('Matching a single header OR a full-text search', function() {
+            verify_compile_success("\"some text\" OR subject ~ \"a phrase\"",
+                                   "(\"some text\" OR subject:\"a phrase\")");
+        });
+
+        it('Matching two headers with AND', function() {
+            verify_compile_success("to ~ \"bob\" AND subject ~ \"a phrase\"",
+                                   "(to:\"bob\" subject:\"a phrase\")");
+        });
+
+        it('Matching two headers with OR', function() {
+            verify_compile_success("to ~ \"bob\" OR subject ~ \"a phrase\"",
+                                   "(to:\"bob\" OR subject:\"a phrase\")");
+        });
+
+        it('Mix of match and non-match with OR', function() {
+            verify_compile_success("to ~ \"bob\" OR subject !~ \"a phrase\"",
+                                   "(to:\"bob\" OR -subject:\"a phrase\")");
+        });
+
+        it('Using NOT with a full-text match', function() {
+            verify_compile_success("NOT \"text\"",
+                                   "-\"text\"");
+        });
+
+        it('Using NOT with a single-header match', function() {
+            verify_compile_success("NOT subject ~ \"foo\"",
+                                   "-subject:\"foo\"");
+        });
+
+        it('Using NOT with AND on a single term', function() {
+            verify_compile_success("\"foo\" AND NOT subject ~ \"foo\"",
+                                   "(\"foo\" -subject:\"foo\")");
+        });
+
+        it('Using NOT with OR on a single term', function() {
+            verify_compile_success("\"foo\" OR NOT subject ~ \"foo\"",
+                                   "(\"foo\" OR -subject:\"foo\")");
+        });
+
+        it('Using NOT with AND on multiple terms', function() {
+            verify_compile_success("\"foo\" AND NOT (subject ~ \"foo\" AND subject ~ \"bar\")",
+                                   "(\"foo\" -(subject:\"foo\" subject:\"bar\"))");
+        });
+
+        it('Using NOT with OR on multiple terms', function() {
+            verify_compile_success("\"foo\" OR NOT (subject ~ \"foo\" OR subject ~ \"bar\")",
+                                   "(\"foo\" OR -(subject:\"foo\" OR subject:\"bar\"))");
+        });
+
+        it('Using NOT with AND on a mix of full-text and header matches', function() {
+            verify_compile_success("to ~ \"me\" AND NOT (\"title\" AND subject ~ \"bar\")",
+                                   "(to:\"me\" -(\"title\" subject:\"bar\"))");
+        });
+
+        it('Using OR with AND on a mix of full-text and header matches', function() {
+            verify_compile_success("to ~ \"me\" OR (\"title\" AND subject ~ \"bar\")",
+                                   "(to:\"me\" OR (\"title\" subject:\"bar\"))");
+        });
+
+        it('Using AND with parentheses', function() {
+            verify_compile_success("(to ~ \"me\" AND from ~ \"bob\") AND (\"title\" AND subject ~ \"bar\")",
+                                   "((to:\"me\" from:\"bob\") (\"title\" subject:\"bar\"))");
+        });
+
+        it('Using OR with parentheses', function() {
+            verify_compile_success("(to ~ \"me\" OR from ~ \"bob\") OR (\"title\" AND subject ~ \"bar\")",
+                                   "((to:\"me\" OR from:\"bob\") OR (\"title\" subject:\"bar\"))");
+        });
+
+        it('Using AND NOT with parentheses', function() {
+            verify_compile_success("(to ~ \"me\" AND NOT from ~ \"bob\") AND NOT (\"title\" AND NOT subject ~ \"bar\")",
+                                   "((to:\"me\" -from:\"bob\") -(\"title\" -subject:\"bar\"))");
+        });
+
+        it('Using OR NOT with parentheses', function() {
+            verify_compile_success("(to ~ \"me\" OR NOT from ~ \"bob\") OR NOT (\"title\" OR NOT subject ~ \"bar\")",
+                                   "((to:\"me\" OR -from:\"bob\") OR -(\"title\" OR -subject:\"bar\"))");
+        });
+
+        it('Multiple levels of parentheses', function() {
+            verify_compile_success("(NOT \"a phrase\" AND NOT (from ~ \"bob\" OR subject ~ \"some subject\" AND NOT \"body\")) AND (\"title\" OR NOT subject ~ \"bar\")",
+                                   "((-\"a phrase\" -(from:\"bob\" OR (subject:\"some subject\" -\"body\"))) (\"title\" OR -subject:\"bar\"))");
+        });
+
+    });
+});


### PR DESCRIPTION
Add support for medium complexity filter expressions. As documented in
the adapter walkthrough, you can combine substring searches on the
following headers:

- from
- to
- subject
- cc
- bcc

along with a full-text search via a single string value, joined by any
logical operators and nested by parentheses.

I might possibly be abusing the error code
RT-ADAPTER-UNSUPPORTED-FILTER to handle cases like searching on a
header not in the above set, unsupported operators like '<', '=',
etc. Let me know if you think I should define more specific error
codes for these cases.

Also fix up the way the adapter was throwing errors--Juttle.proc.base
provides a better way to throw errors, so use that.

This fixes #8.

@davidvgalbraith @go-oleg 