### PR TITLE
Update to juttle 0.2.0:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,13 @@ addons:
 
 before_install:
     - export CXX="g++-4.8"
+    - npm install juttle@0.2.x
 
 node_js:
     - '4.2'
     - '5.0'
 
 before_script:
-    - npm install juttle@0.1.x
     - npm install -g jshint
     - npm install -g jscs
 

--- a/lib/gmail-adapter.js
+++ b/lib/gmail-adapter.js
@@ -10,8 +10,8 @@ var FilterGmailCompiler = require('./filter-gmail-compiler');
 
 var auth;
 
-var Read = Juttle.proc.base.extend({
-    procName: 'read-gmail',
+var Read = Juttle.proc.source.extend({
+    procName: 'read gmail',
 
     initialize: function(options, params, pname, location, program, juttle) {
         this.logger.debug('intitialize', options, params);

--- a/lib/gmail-adapter.js
+++ b/lib/gmail-adapter.js
@@ -29,9 +29,7 @@ var Read = Juttle.proc.source.extend({
         // One of 'from', 'to', or 'last' must be present.
         var opts = _.intersection(_.keys(options), time_related_options);
         if (opts.length === 0) {
-            // Waiting on a juttle release that incorporates https://github.com/juttle/juttle/pull/108
-            //throw this.compile_error('RT-MISSING-TIME-RANGE-ERROR');
-            throw new Error('Error: One of -from, -to, or -last must be specified to define a query time range');
+            throw this.compile_error('RT-MISSING-TIME-RANGE-ERROR');
         }
 
         // If 'from'/'to' are present, 'last' can not be present.

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
       "underscore": "^1.8.3"
   },
   "peerDependencies": {
-      "juttle": "0.1.x"
+      "juttle": "0.2.x"
   },
   "devDependencies": {
       "chai": "^3.4.1",

--- a/test/gmail-adapter.spec.js
+++ b/test/gmail-adapter.spec.js
@@ -29,12 +29,11 @@ describe('gmail adapter', function() {
 
     describe(' properly returns errors for invalid timeranges like', function() {
 
-        // Waiting on a juttle release that incorporates https://github.com/juttle/juttle/pull/108
-        it.skip(' no -from/-to/-last specified', function() {
+        it(' no -from/-to/-last specified', function() {
             return check_juttle({
                 program: 'read gmail | view table'
             }).catch(function(err) {
-                expect(err.code).to.equal('RT-MISSING-TIMERANGE-ERROR');
+                expect(err.code).to.equal('RT-MISSING-TIME-RANGE-ERROR');
             });
         });
 


### PR DESCRIPTION
- Update package.json
- The base class for the read proc should be source. Fix that.
- Start using the new RT-MISSING-TIME-RANGE-ERROR that was added in 0.2.0.

@demmer @go-oleg @bkutil 