### PR TITLE
Ensure lint failures are travis failures.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "mocha",
     "jshint": "jshint *.js lib/*.js test/*.js",
     "style": "jscs *.js lib/*.js test/*.js",
-    "lint": "npm run jshint & npm run style"
+    "lint": "npm run jshint && npm run style"
   },
   "dependencies": {
     "batchelor": "^2.0.1",


### PR DESCRIPTION
Add missing && which was messing with the return value from the jshint
command.

@mnibecker you're an expert on this now!