### PR TITLE
Be more flexible about juttle dependencies.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ addons:
 
 before_install:
     - export CXX="g++-4.8"
-    - npm install juttle@0.2.x
+    - npm install juttle@^0.2.x
 
 node_js:
     - '4.2'

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "urlsafe-base64": "^1.0.0"
   },
   "peerDependencies": {
-    "juttle": "0.2.x"
+    "juttle": ">= 0.2.0"
   },
   "devDependencies": {
     "chai": "^3.4.1",


### PR DESCRIPTION
This is a part of the fix for
https://github.com/juttle/juttle/issues/145. Have the peer dependency
be on anything greater than 0.2.0.

@demmer 