### PR TITLE
Eliminate useless `emit_eof` call in `Write`

### DIFF
--- a/lib/write.js
+++ b/lib/write.js
@@ -182,7 +182,6 @@ var Write = Juttle.proc.sink.extend({
         // We are only done once we have received an eof and once
         // every pending message has been sent.
         if (self.got_eof && self.in_progress_writes === 0) {
-            self.emit_eof();
             self.done();
         }
     },


### PR DESCRIPTION
The call is a noop (because `Write` is a sink).

See juttle/juttle#131.