### PR TITLE
Remove pname/juttle arguments from read.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ addons:
 
 before_install:
     - export CXX="g++-4.8"
-    - npm install juttle@^0.2.x
+    - npm install juttle@^0.3.x
 
 node_js:
     - '4.2'

--- a/docs/read.md
+++ b/docs/read.md
@@ -63,10 +63,8 @@ initialize: function(options, params, pname, location, program, juttle) {...}
 
 * ``options``: The options provided to the ``read gmail`` proc in the juttle program. ``-from``, ``-to``, etc. are all examples of options.
 * ``params``: The filter expression is passed as ``params.filter_ast``.
-* ``pname``: XXX/mstemm is this needed?
 * ``location``: The location in the juttle program where this proc is located. It has been saved to ``this.location`` by the parent class.
 * ``program``: A reference to the associated ``Program`` object.
-* ``juttle``: XXX/mstemm is this needed?
 
 ```
 start: function() {...}

--- a/lib/read.js
+++ b/lib/read.js
@@ -12,7 +12,7 @@ var auth;
 var Read = Juttle.proc.source.extend({
     procName: 'read gmail',
 
-    initialize: function(options, params, pname, location, program, juttle) {
+    initialize: function(options, params, location, program) {
         this.logger.debug('intitialize', options, params);
         this.gmail = google.gmail('v1');
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "urlsafe-base64": "^1.0.0"
   },
   "peerDependencies": {
-    "juttle": ">= 0.2.0"
+    "juttle": ">= 0.3.0"
   },
   "devDependencies": {
     "chai": "^3.4.1",


### PR DESCRIPTION
Update to reflect https://github.com/juttle/juttle/pull/154 by
removing the pname and juttle arguments to the read proc
constructor. Also remove mention of them from the readme.

Update package.json to depend on >= 0.3.0 as that's the minimum juttle
version that now works.

@demmer @go-oleg 