### PR TITLE
Remove space in package.json dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "urlsafe-base64": "^1.0.0"
   },
   "peerDependencies": {
-    "juttle": ">= 0.3.0"
+    "juttle": ">=0.3.0"
   },
   "devDependencies": {
     "chai": "^3.4.1",


### PR DESCRIPTION
Might be causing conflicts in outrigger where all the adapters are
pulled in.