### PR TITLE
With juttle 0.3.0, adapter config elements below .juttle-config should

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ This file documents all notable changes to juttle-gmail-adapter. The release num
 Released 2016-01-20
 
 ### Major Changes
+ - IMPORTANT CHANGE: As a part of the upgrade to juttle 0.3.0, the format for ``juttle-config.js`` files has changed. The configuration for the gmail adapter is now associated with the property ``gmail`` and not ``juttle-gmail-adapter``. So configuration files containing:
+
+```
+{
+    "adapters": {
+        "juttle-gmail-adapter": {...}
+    }
+}
+```
+
+Should change to:
+
+```
+{
+    "adapters": {
+        "gmail": {...}
+    }
+}
+```
 
 ### Minor Changes
 - Update to handle changes in juttle 0.3.0.

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ assocated with the authenticated user, to verify that the token was created succ
 ```
 {
   "adapters": {
-    "juttle-gmail-adapter": {
+    "gmail": {
       "client-credentials": {
         "installed": {
           "client_id": "--your-client-id--",
@@ -125,17 +125,17 @@ have an existing "adapters" section, for example:
 ```
 {
   "adapters": {
-    "juttle-twitter-adapter": {...}
+    "twitter": {...}
   }
 }
 ```
 
-Add the juttle-gmail-adapter section as a peer item below "adapters":
+Add the gmail section as a peer item below "adapters":
 ```
 {
   "adapters": {
-    "juttle-twitter-adapter": {...},
-    "juttle-gmail-adapter": {...}
+    "twitter": {...},
+    "gmail": {...}
   }
 }
 ```


### PR DESCRIPTION
be XXX and not juttle-xxx-adapter.

Update READMEs to reflect this and prominently mention in CHANGELOG.md.

@go-oleg @rlgomes @bkutil 