### PR TITLE
Also use local juttle config if available.

### DIFF
--- a/test/gmail-adapter.spec.js
+++ b/test/gmail-adapter.spec.js
@@ -17,21 +17,21 @@ describe('gmail adapter', function() {
         // source files.
 
         var config = read_config();
+        var gmail_config;
 
-        if (! _.has(config, "adapters")) {
+        if (_.has(config, "adapters") &&
+            _.has(config.adapters, "gmail")) {
+            gmail_config = config.adapters.gmail;
+        } else {
+
             if (! _.has(process.env, "JUTTLE_GMAIL_CONFIG") ||
                 process.env.JUTTLE_GMAIL_CONFIG === '') {
                 throw new Error("To run this test, you must provide the adapter config via the environment as JUTTLE_GMAIL_CONFIG.");
             }
-            var gmail_config = JSON.parse(process.env.JUTTLE_GMAIL_CONFIG);
-            config = {
-                adapters: {
-                    gmail: gmail_config
-                }
-            };
+            gmail_config = JSON.parse(process.env.JUTTLE_GMAIL_CONFIG);
         }
 
-        var adapter = GmailAdapter(config.adapters.gmail, Juttle);
+        var adapter = GmailAdapter(gmail_config, Juttle);
 
         Juttle.adapters.register(adapter.name, adapter);
     });

--- a/test/gmail-adapter.spec.js
+++ b/test/gmail-adapter.spec.js
@@ -4,25 +4,34 @@ var Juttle = require('juttle/lib/runtime').Juttle;
 var GmailAdapter = require('../');
 var check_juttle = juttle_test_utils.check_juttle;
 var expect = require('chai').expect;
+var read_config = require('juttle/lib/config/read-config');
 
 describe('gmail adapter', function() {
 
     before(function() {
 
-        // The config is provided via the environment to avoid putting
-        // sensitive information like ids/auth tokens in source
-        // files. If you want to run this test using your own setup,
-        // json stringify the portion of your config under the
-        // "juttle-gmail-adapter" object and set it in the environment
-        // as JUTTLE_GMAIL_CONFIG.
+        // Try to read from the config file first. If not present,
+        // look in the environment variable JUTTLE_GMAIL_CONFIG. In
+        // TravisCI, the config is provided via the environment to
+        // avoid putting sensitive information like ids/auth tokens in
+        // source files.
 
-        if (! _.has(process.env, "JUTTLE_GMAIL_CONFIG") ||
-            process.env.JUTTLE_GMAIL_CONFIG === '') {
-            throw new Error("To run this test, you must provide the adapter config via the environment as JUTTLE_GMAIL_CONFIG.");
+        var config = read_config();
+
+        if (! _.has(config, "adapters")) {
+            if (! _.has(process.env, "JUTTLE_GMAIL_CONFIG") ||
+                process.env.JUTTLE_GMAIL_CONFIG === '') {
+                throw new Error("To run this test, you must provide the adapter config via the environment as JUTTLE_GMAIL_CONFIG.");
+            }
+            var gmail_config = JSON.parse(process.env.JUTTLE_GMAIL_CONFIG);
+            config = {
+                adapters: {
+                    gmail: gmail_config
+                }
+            };
         }
 
-        var config = JSON.parse(process.env.JUTTLE_GMAIL_CONFIG);
-        var adapter = GmailAdapter(config, Juttle);
+        var adapter = GmailAdapter(config.adapters.gmail, Juttle);
 
         Juttle.adapters.register(adapter.name, adapter);
     });


### PR DESCRIPTION
Update the unit test to try read_config first and fall back to the
environment only if read_config didn't find anything.

@juttle/developers 