### PR TITLE
Updates to credentials setup process.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,11 @@ You'll use this file in the next step.
 
 You need to create an oauth2 token that allows this program to read your email on your behalf.
 
-To do this, run `node create_oauth_token.js` from the juttle-gmail-adapter directory.
+To do this, run `node create_oauth_token.js
+<path-to-client_secret.json>`. `create_oauth_token.js` is in the
+top-level directory where juttle-gmail-adapter is installed
+(i.e. wherever you ran `git clone` for github, under
+`node_modules/juttle-gmail-adapter` for npm).
 
 This will provide a json config block to add to your `.juttle/config.js` file.
 

--- a/README.md
+++ b/README.md
@@ -52,9 +52,12 @@ Configuration involves these steps:
 
 ### Create application credentials
 
-To create application credentials, follow the
-[nodejs quickstart instructions](https://developers.google.com/gmail/api/quickstart/nodejs). This
-will result in a file on disk titled `client_secret.json` with this structure:
+To create application credentials, follow the instructions under
+**Step 1: Turn on the Gmail API** on the
+[nodejs quickstart instructions page](https://developers.google.com/gmail/api/quickstart/nodejs). (Steps
+2-4 are not necessary--you only need step 1 to create the client api
+credentials). This will result in a file on disk titled
+`client_secret.json` with this structure:
 
 ```
 {

--- a/create_oauth_token.js
+++ b/create_oauth_token.js
@@ -90,7 +90,7 @@ function storeToken(credentials, token) {
     console.log('Add the following json block to your .juttle/config.{js,json} file:');
     var juttle_config = {
         adapters: {
-            "juttle-gmail-adapter": {
+            "gmail": {
                 "client-credentials": credentials,
                 "oauth2-token": token,
             }
@@ -99,7 +99,7 @@ function storeToken(credentials, token) {
 
     console.log(JSON.stringify(juttle_config, null, 4));
 
-    console.log("If you already have a \"adapters\" section, add the \"juttle-gmail-adapter\" section under the existing \"adapters\" section.");
+    console.log("If you already have a \"adapters\" section, add the \"gmail\" section under the existing \"adapters\" section.");
 }
 
 /**

--- a/create_oauth_token.js
+++ b/create_oauth_token.js
@@ -9,7 +9,7 @@ var SCOPES = ['https://www.googleapis.com/auth/gmail.readonly', 'https://www.goo
 var TOKEN_PATH = 'gmail-nodejs-quickstart.json';
 
 // Load client secrets from a local file.
-fs.readFile('client_secret.json', function processClientSecrets(err, content) {
+fs.readFile(process.argv[2], function processClientSecrets(err, content) {
     if (err) {
         console.log('Error loading client secret file: ' + err);
         return;


### PR DESCRIPTION
Mike recently went through the steps of obtaining gmail
credentials. Here's his feedback:

 - You only need to do step 1 of the nodejs quickstart page, so explicitly state that.

 - Although the docs had captured the juttle-gmail-adapter -> gmail
   change in juttle-config.js, the script that generates the sample
   config wasn't updated. Fix that.

@demmer 