### PR TITLE
Implement Gmail filter compiler using StaticFilterCompilerBase (prototype)

### DIFF
--- a/lib/filter-gmail-compiler.js
+++ b/lib/filter-gmail-compiler.js
@@ -1,10 +1,13 @@
+'use strict';
+
 // Compiler that transforms filter expression AST into a gmail search expression.
 //
 // The expression is returned from the compile method.
 
-var ASTVisitor = require('juttle/lib/compiler/ast-visitor');
+var StaticFilterCompilerBase = require('./static-filter-compiler-base');
 var JuttleErrors = require('juttle/lib/errors');
 var JuttleMoment = require('juttle/lib/moment').JuttleMoment;
+var values = require('juttle/lib/runtime/values');
 var _ = require('underscore');
 
 // FilterGmailCompiler derives from ASTVisitor which provides a way to
@@ -18,67 +21,41 @@ var _ = require('underscore');
 // tree is traversed, these items are combined into a complete gmail
 // search expression. This is used when reading messages.
 
-var FilterGmailCompiler = ASTVisitor.extend({
-    initialize: function(options) {
+class FilterGmailCompiler extends StaticFilterCompilerBase {
+    constructor(options) {
+        super();
+
         this.location = options.location;
         this.supported_headers = ["from", "to", "subject", "cc", "bcc"];
-    },
+    }
 
-    compile: function(node) {
-        return this.visit(node);
-    },
-
-    visitStringLiteral: function(node) {
-        return node.value;
-    },
-
-    visitFilterLiteral: function(node) {
-        return this.visit(node.ast);
-    },
-
-    visitUnaryExpression: function(node) {
-        switch (node.operator) {
-            case 'NOT':
-                return '-' + this.visit(node.expression);
-
-            // '*' is the field dereferencing operator. For example,
-            // given a search string from ~ 'bob', the UnaryExpression
-            // * on from means "the field called from".
-            case '*':
-                return this.visit(node.expression);
-
-            default:
-
-                throw JuttleErrors.compileError('RT-ADAPTER-UNSUPPORTED-FILTER',
-                                                {proc: 'read gmail', filter: "operator " + node.operator});
+    compileLiteral(node) {
+        if (node.type == 'StringLiteral') {
+            return node.value;
+        } else {
+            throw JuttleErrors.compileError('RT-ADAPTER-UNSUPPORTED-FILTER',
+                                            {proc: 'read gmail', filter: values.typeDisplayName(values.typeOf(values.fromAST(node)))});
         }
-    },
+    }
 
-    visitBinaryExpression: function(node) {
-        var left, right, filter, header, value;
+    compileField(node) {
+        return node.name;
+    }
+
+    compileFulltextTerm(node) {
+        return "\"" + node.value + "\"";
+    }
+
+    compileExpressionTerm(node) {
+        var filter, header, value;
 
         switch (node.operator) {
-            case 'AND':
-                left = this.visit(node.left);
-                right = this.visit(node.right);
-
-                filter = "(" + left + " " + right + ")";
-                break;
-
-            case 'OR':
-                left = this.visit(node.left);
-                right = this.visit(node.right);
-
-                filter = "(" + left + " OR " + right + ")";
-
-                break;
-
             // The gmail search syntax only supports substring matches
             // (as compared to exact matches), so we only support
             // substring matches here.
             case '=~':
-                header = this.visit(node.left);
-                value = this.visit(node.right);
+                header = this.compile(node.left);
+                value = this.compile(node.right);
 
                 if (! _.contains(this.supported_headers, header)) {
                     throw JuttleErrors.compileError('RT-ADAPTER-UNSUPPORTED-FILTER',
@@ -90,8 +67,8 @@ var FilterGmailCompiler = ASTVisitor.extend({
                 break;
 
             case '!~':
-                header = this.visit(node.left);
-                value = this.visit(node.right);
+                header = this.compile(node.left);
+                value = this.compile(node.right);
 
                 if (! _.contains(this.supported_headers, header)) {
                     throw JuttleErrors.compileError('RT-ADAPTER-UNSUPPORTED-FILTER',
@@ -108,23 +85,25 @@ var FilterGmailCompiler = ASTVisitor.extend({
         }
 
         return filter;
-    },
-
-    visitExpressionFilterTerm: function(node) {
-        return this.visit(node.expression);
-    },
-
-    visitSimpleFilterTerm: function(node) {
-        switch (node.expression.type) {
-            case 'StringLiteral':
-            case 'FilterLiteral':
-                return "\"" + this.visit(node.expression) + "\"";
-
-            default:
-                throw JuttleErrors.compileError('RT-ADAPTER-UNSUPPORTED-FILTER',
-                                                {proc: 'read gmail', filter: "filter term " + node.expression.type});
-        }
     }
-});
+
+    compileAndExpression(node) {
+        var left = this.compile(node.left);
+        var right = this.compile(node.right);
+
+        return "(" + left + " " + right + ")";
+    }
+
+    compileOrExpression(node) {
+        var left = this.compile(node.left);
+        var right = this.compile(node.right);
+
+        return "(" + left + " OR " + right + ")";
+    }
+
+    compileNotExpression(node) {
+        return '-' + this.compile(node.expression);
+    }
+}
 
 module.exports = FilterGmailCompiler;

--- a/lib/static-filter-compiler-base.js
+++ b/lib/static-filter-compiler-base.js
@@ -1,0 +1,199 @@
+'use strict';
+
+let errors = require('juttle/lib/errors');
+let ASTVisitor = require('juttle/lib/compiler/ast-visitor');
+
+// Base class for compilers that transform filter expression ASTs into native
+// queries. To be inherited and extended by adapters.
+class StaticFilterCompilerBase {
+    constructor(adapter) {
+        this.adapter = adapter;
+        this.visitor = new StaticFilterCompilerBaseVisitor(this);
+    }
+
+    compile() {
+        return this.visitor.visit.apply(this.visitor, arguments);
+    }
+
+    compileLiteral() {
+        throw errors.compileError('RT-FILTER-FEATURE-NOT-SUPPORTED', {
+            adapter: this.adapter,
+            feature: 'values'
+        });
+    }
+
+    compileField() {
+        throw errors.compileError('RT-FILTER-FEATURE-NOT-SUPPORTED', {
+            adapter: this.adapter,
+            feature: 'fields'
+        });
+    }
+
+    compileExpressionTerm() {
+        throw errors.compileError('RT-FILTER-FEATURE-NOT-SUPPORTED', {
+            adapter: this.adapter,
+            feature: 'comparison'
+        });
+    }
+
+    compileFulltextTerm() {
+        throw errors.compileError('RT-FILTER-FEATURE-NOT-SUPPORTED', {
+            adapter: this.adapter,
+            feature: 'fulltext search'
+        });
+    }
+
+    compileAndExpression() {
+        throw errors.compileError('RT-FILTER-FEATURE-NOT-SUPPORTED', {
+            adapter: this.adapter,
+            feature: 'the AND operator'
+        });
+    }
+
+    compileOrExpression() {
+        throw errors.compileError('RT-FILTER-FEATURE-NOT-SUPPORTED', {
+            adapter: this.adapter,
+            feature: 'the OR operator'
+        });
+    }
+
+    compileNotExpression() {
+        throw errors.compileError('RT-FILTER-FEATURE-NOT-SUPPORTED', {
+            adapter: this.adapter,
+            feature: 'the NOT operator'
+        });
+    }
+}
+
+// Visitor which drives StaticFilterCompilerBase.
+class StaticFilterCompilerBaseVisitor extends ASTVisitor {
+    constructor(compiler) {
+        super();
+
+        this.compiler = compiler;
+    }
+
+    visitNullLiteral() {
+        return this.compiler.compileLiteral.apply(this.compiler, arguments);
+    }
+
+    visitBooleanLiteral() {
+        return this.compiler.compileLiteral.apply(this.compiler, arguments);
+    }
+
+    visitNumericLiteral() {
+        return this.compiler.compileLiteral.apply(this.compiler, arguments);
+    }
+
+    visitInfinityLiteral() {
+        return this.compiler.compileLiteral.apply(this.compiler, arguments);
+    }
+
+    visitNaNLiteral() {
+        return this.compiler.compileLiteral.apply(this.compiler, arguments);
+    }
+
+    visitStringLiteral() {
+        return this.compiler.compileLiteral.apply(this.compiler, arguments);
+    }
+
+    visitRegularExpressionLiteral() {
+        return this.compiler.compileLiteral.apply(this.compiler, arguments);
+    }
+
+    visitMomentLiteral() {
+        return this.compiler.compileLiteral.apply(this.compiler, arguments);
+    }
+
+    visitDurationLiteral() {
+        return this.compiler.compileLiteral.apply(this.compiler, arguments);
+    }
+
+    visitFilterLiteral() {
+        return this.compiler.compileLiteral.apply(this.compiler, arguments);
+    }
+
+    visitArrayLiteral() {
+        return this.compiler.compileLiteral.apply(this.compiler, arguments);
+    }
+
+    visitObjectLiteral() {
+        return this.compiler.compileLiteral.apply(this.compiler, arguments);
+    }
+
+    visitField() {
+        return this.compiler.compileField.apply(this.compiler, arguments);
+    }
+
+    visitUnaryExpression(node) {
+        switch (node.operator) {
+            case 'NOT':
+                return this.compiler.compileNotExpression.apply(this.compiler, arguments);
+
+            case '*':
+                let extraArgs = Array.prototype.slice.call(arguments, 1);
+
+                return this.compiler.compileField.apply(
+                    this.compiler,
+                    [{
+                        type: 'Field',
+                        name: node.expression.value,
+                        location: node.expression.location
+                    }].concat(extraArgs)
+                );
+
+            default:
+                throw new Error('Invalid operator: ' + node.operator + '.');
+        }
+    }
+
+    visitBinaryExpression(node) {
+        switch (node.operator) {
+            case 'AND':
+                return this.compiler.compileAndExpression.apply(this.compiler, arguments);
+
+            case 'OR':
+                return this.compiler.compileOrExpression.apply(this.compiler, arguments);
+
+            case '==':
+            case '!=':
+            case '=~':
+            case '!~':
+            case '<':
+            case '>':
+            case '<=':
+            case '>=':
+            case 'in':
+                return this.compiler.compileExpressionTerm.apply(this.compiler, arguments);
+
+            default:
+                throw new Error('Invalid operator: ' + node.operator + '.');
+        }
+    }
+
+    visitExpressionFilterTerm(node) {
+        var extraArgs = Array.prototype.slice.call(arguments, 1);
+
+        return this.visit.apply(this, [node.expression].concat(extraArgs));
+    }
+
+    visitSimpleFilterTerm(node) {
+        var extraArgs = Array.prototype.slice.call(arguments, 1);
+
+        switch (node.expression.type) {
+            case 'StringLiteral':
+                return this.compiler.compileFulltextTerm.apply(
+                    this.compiler,
+                    [node.expression].concat(extraArgs)
+                );
+
+            case 'FilterLiteral':
+                return this.visit.apply(this, [node.expression].concat(extraArgs));
+
+            default:
+                throw new Error('Invalid node type: ' + node.expression.type + '.');
+        }
+    }
+}
+
+module.exports = StaticFilterCompilerBase;

--- a/test/filter-gmail-compiler.spec.js
+++ b/test/filter-gmail-compiler.spec.js
@@ -36,15 +36,6 @@ describe('gmail filter', function() {
 
     describe(' properly returns errors for invalid filtering expressions like ', function() {
 
-        var invalid_unary_operators = ['!', '-'];
-
-        invalid_unary_operators.forEach(function(op) {
-            it('using unary operator ' + op + ' in field specifications', function() {
-                verify_compile_error("subject ~ " + op + " \"foo\"",
-                                     "operator " + op);
-            });
-        });
-
         var invalid_operators = ['==', '!=', '<', '<=', '>', '>=', 'in'];
         invalid_operators.forEach(function(op) {
             it('using ' + op + ' in field comparisons', function() {
@@ -56,11 +47,6 @@ describe('gmail filter', function() {
         it('matching on unsupported headers', function() {
             verify_compile_error("not_a_header ~ \"foo\"",
                                  "searching on header not_a_header");
-        });
-
-        it('not a filter expression or string', function() {
-            verify_compile_error("+ 1",
-                                 "filter term UnaryExpression");
         });
     });
 


### PR DESCRIPTION
The goal was to do roughly 1:1 port of the existing filter compiler to judge the `StaticFilterCompilerBase` API.

Note the implementation includes a slightly modified version of `static-filter-compiler-base.js` into the code base because `juttle` 0.4.x doesn’t contain it.

**Not for merge!**