### PR TITLE
Remove unnecessary visitFilterLiteral.

### DIFF
--- a/lib/filter-gmail-compiler.js
+++ b/lib/filter-gmail-compiler.js
@@ -41,10 +41,6 @@ class FilterGmailCompiler extends StaticFilterCompiler {
         return node.value;
     }
 
-    visitFilterLiteral(node) {
-        return this.visit(node.ast);
-    }
-
     visitUnaryExpression(node) {
         if (node.operator === 'NOT') {
             return '-' + this.visit(node.argument);


### PR DESCRIPTION
Feedback from dmajda--visitFilterLiteral unnecessary as
FilterSimplifier inlines FilterLiteral nodes.

@dmajda 