### PR TITLE
Get rid of top level index.js.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,0 @@
-module.exports = require('./lib/');

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "homepage": "https://github.com/juttle/juttle-gmail-adapter",
   "bugs": "https://github.com/juttle/juttle-gmail-adapter/issues",
   "license": "Apache-2.0",
-  "main": "index.js",
+  "main": "lib/index.js",
   "repository": "juttle/juttle-gmail-adapter",
   "scripts": {
     "test": "gulp test",


### PR DESCRIPTION
Follow the example of juttle-adapter-template and have the main of the
package be lib/index.js.

@rlgomes 