### PR TITLE
Add ecosystem link to juttle-gmail-adapter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ $ npm install juttle-gmail-adapter
 
 ## Ecosystem
 
-Here's how the juttle-gmail-adapter module fits into the overall [Juttle Ecosystem](https://github.com/juttle/juttle/blob/master/docs/juttle_ecosystem.md):
+The juttle-gmail-adapter fits into the overall Juttle Ecosystem as one of the adapters in the [below diagram](https://github.com/juttle/juttle/blob/master/docs/juttle_ecosystem.md):
 
 [![Juttle Ecosystem](https://github.com/juttle/juttle/raw/master/docs/images/JuttleEcosystemDiagram.png)](https://github.com/juttle/juttle/blob/master/docs/juttle_ecosystem.md)
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ the adapter need to be installed side-by-side:
 $ npm install juttle
 $ npm install juttle-gmail-adapter
 ```
+
+## Ecosystem
+
+Here's how the juttle-gmail-adapter module fits into the overall [Juttle Ecosystem](https://github.com/juttle/juttle/blob/master/docs/juttle_ecosystem.md):
+
+[![Juttle Ecosystem](https://github.com/juttle/juttle/raw/master/docs/images/JuttleEcosystemDiagram.png)](https://github.com/juttle/juttle/blob/master/docs/juttle_ecosystem.md)
+
 ## Configuration
 
 Configuration involves these steps:


### PR DESCRIPTION
Add an ecosystem section to each README to show its part in the
overall architecture.

@VladVega @rlgomes 